### PR TITLE
specify ruby version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby "2.4.6"
 
 gem 'rails',                   '5.2.3'
 gem 'railties',                '5.2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -418,5 +418,8 @@ DEPENDENCIES
   web-console (= 3.5.1)
   will_paginate (= 3.1.6)
 
+RUBY VERSION
+   ruby 2.4.6p354
+
 BUNDLED WITH
-   1.16.2
+   2.0.1


### PR DESCRIPTION
New Heroku "highly recommends" specifying Ruby version in Gemfile.
When in Rome...
